### PR TITLE
Fix DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -6,29 +6,29 @@
 
 1. [Acknowledgements](#acknowledgements)
 2. [Design and Implementation](#design-and-implementation)
-    - [Architecture Overview](#architecture-overview)
-    - [UI Component](#ui-component)
-    - [Parser Component](#parser-component)
-    - [Command Component](#command-component)
-    - [Model Component](#model-component)
-    - [Storage Component](#storage-component)
-    - [SessionContainer](#sessioncontainer)
+   - [Architecture Overview](#architecture-overview)
+   - [UI Component](#ui-component)
+   - [Parser Component](#parser-component)
+   - [Command Component](#command-component)
+   - [Model Component](#model-component)
+   - [Storage Component](#storage-component)
+   - [SessionContainer](#sessioncontainer)
 3. [Implementation: Feature Deep-Dives](#implementation-feature-deep-dives)
-    - [Add a Card (`add`)](#add-a-card)
-    - [Delete a Card (`delete`)](#delete-a-card)
-    - [Edit a Card (`edit`)](#edit-a-card)
-    - [View a Card (`view`)](#view-a-card)
-    - [Flip a Card (`flip`)](#flip-a-card)
-    - [Find Cards (`find`)](#find-cards)
-    - [List Cards (`list`)](#list-cards)
-    - [Save to Test Set (`save`)](#save-to-test-set)
-    - [Remove from Test Set (`remove`)](#remove-from-test-set)
-    - [Test a Set (`test`)](#test-a-set)
-    - [Tag a Card (`tag`)](#tag-a-card)
-    - [List All Tags (`tags`)](#list-all-tags)
-    - [Exit (`exit`)](#exit)
-    - [Storage: Save Operation](#storage-save-operation)
-    - [Storage: Load Operation](#storage-load-operation)
+   - [Add a Card (`add`)](#add-a-card)
+   - [Delete a Card (`delete`)](#delete-a-card)
+   - [Edit a Card (`edit`)](#edit-a-card)
+   - [View a Card (`view`)](#view-a-card)
+   - [Flip a Card (`flip`)](#flip-a-card)
+   - [Find Cards (`find`)](#find-cards)
+   - [List Cards (`list`)](#list-cards)
+   - [Save to Test Set (`save`)](#save-to-test-set)
+   - [Remove from Test Set (`remove`)](#remove-from-test-set)
+   - [Test a Set (`test`)](#test-a-set)
+   - [Tag a Card (`tag`)](#tag-a-card)
+   - [List All Tags (`tags`)](#list-all-tags)
+   - [Exit (`exit`)](#exit)
+   - [Storage: Save Operation](#storage-save-operation)
+   - [Storage: Load Operation](#storage-load-operation)
 4. [Product Scope](#product-scope)
 5. [User Stories](#user-stories)
 6. [Non-Functional Requirements](#non-functional-requirements)
@@ -53,16 +53,15 @@ The following tools and libraries were used during development:
 
 ### Architecture Overview
 
-FlashyCard follows a layered architecture with clear separation of concerns. The core architecture of follows a design pattern for Command Line Interface applications.
+FlashyCard follows a layered architecture with clear separation of concerns. The core architecture follows a design pattern for Command Line Interface applications.
 
 The execution flows through several distinct components and objects that handle user interaction, parsing, execution, data management, and persistence respectively. The diagram below shows all major components and how they interact.
 
 **Architecture Component Diagram:**
-![Architecture Componet Diagram.png](diagram/Architecture%20Componet%20Diagram.png)
+
+![Architecture Component Diagram](diagram/Architecture%20Componet%20Diagram.png)
 
 **Component Relationships:**
-
-The diagram above shows the main components and their relationships:
 
 - **`FlashyCard`** is the entry point. It wires all components together and runs the main input loop.
 - **`Ui`** handles all terminal input and output (reading commands, printing messages).
@@ -87,17 +86,17 @@ The `Ui` component is responsible for reading user input from `System.in` and di
 
 #### Class Diagram
 
-![UI_class_diagram.png](diagram/UI_class_diagram.png)
+![UI Class Diagram](diagram/UI_class_diagram.png)
 
 #### How the UI Component Works
 
-The `Ui` class wraps a `java.util.Scanner` that reads from `System.in`. The `FlashyCard.run()` loop calls `ui.readCommand()` to block and wait for each line of input. After a `Command` executes, individual `show*` methods are called to display results. All output ultimately goes to `System.out.println()`.
+The `Ui` class wraps a `java.util.Scanner` that reads from `System.in`. The `FlashyCard.run()` loop calls `ui.readCommand()` to block and wait for each line of input. After a `Command` executes, individual `show*` methods are called to display results.
 
-The `startStudySession()` method is a special interactive loop that drives the `test` command, it walks the user card-by-card through a `List<Card>`, asking them to self evaluate.
+The `startStudySession()` method is a special interactive loop that drives the `test` command — it walks the user card-by-card through a `List<Card>`.
 
 #### Sequence Diagram: Main Application Loop
 
-![seq_main_loop.png](diagram/seq_main_loop.png)
+![Main Loop Sequence Diagram](diagram/seq_main_loop.png)
 
 ---
 
@@ -118,16 +117,17 @@ The `Parser` component transforms a raw user input string into a concrete `Comma
 
 #### Class Diagram
 
-![class_diagram.png](diagram/class_diagram.png)
+![Parser Class Diagram](diagram/class_diagram.png)
 
 #### Sequence Diagram: Parsing a Command
 
-![seq_parsing.png](diagram/seq_parsing.png)
+![Parse Flow Sequence Diagram](diagram/seq_parsing.png)
+
 ---
 
 ### Command Component
 
-`Command.java` and all `XxxCommand.java` classes.
+**API:** `Command.java` and all `XxxCommand.java` classes.
 
 All commands extend the abstract `Command` class and override:
 
@@ -139,19 +139,19 @@ The `isExit()` method defaults to `false` and is overridden only by `ExitCommand
 
 #### Command Class Hierarchy Diagram
 
-![command_class_hierachy.png](diagram/command_class_hierachy.png)
+![Command Class Hierarchy](diagram/command_class_hierachy.png)
 
 ---
 
 ### Model Component
 
-`Card.java`, `KnowledgeBase.java`, `StudySession.java`
+**API:** `Card.java`, `KnowledgeBase.java`, `StudySession.java`
 
 The Model component stores all application data in memory.
 
 #### Class Diagram
 
-![model_class_diagram.png](diagram/model_class_diagram.png)
+![Model Class Diagram](diagram/model_class_diagram.png)
 
 #### Design Notes
 
@@ -163,13 +163,13 @@ The Model component stores all application data in memory.
 
 ### Storage Component
 
-`Storage.java`
+**API:** `Storage.java`
 
 The `Storage` component is responsible for persisting all `Card` objects and test sets to disk, and reloading them on application startup.
 
 #### Class Diagram
 
-![storage_class_diagram.png](diagram/storage_class_diagram.png)
+![Storage Class Diagram](diagram/storage_class_diagram.png)
 
 #### File Format
 
@@ -200,19 +200,19 @@ SET:mySet|1,2
 
 ### SessionContainer
 
-`SessionContainer.java`
+**API:** `SessionContainer.java`
 
-`SessionContainer` holds **transient** state that lives for one application run only, it is never persisted to disk.
+`SessionContainer` holds **transient** state that lives for one application run only — it is never persisted to disk.
 
 #### Class Diagram
 
-![sessioncontainer_class_diagram.png](diagram/sessioncontainer_class_diagram.png)
+![SessionContainer Class Diagram](diagram/sessioncontainer_class_diagram.png)
 
-`lastSearchResults` is populated by `FindCommand`, `ListCommand`, and `TestCommand`. It is consumed by `SaveCommand` when the user types `save all s/mySet`.
+`lastSearchResults` is populated by **`ListCommand`** and **`TestCommand`** only. `FindCommand` does **not** populate `lastSearchResults` — it only displays matching cards without storing them in the session. `SaveCommand` consumes `lastSearchResults` when the user types `save all s/mySet`.
 
 ---
 
-## Implementation: Feature Deep Dives
+## Implementation: Feature Deep-Dives
 
 This section explains each command in detail, including step-by-step walkthrough and sequence diagrams.
 
@@ -232,18 +232,18 @@ This section explains each command in detail, including step-by-step walkthrough
 2. `Parser.parse()` extracts the command word `"add"` and delegates to `AddCommandParser`.
 3. `AddCommandParser` applies the regex, extracts named groups `question` and `answer`, and returns `new AddCommand(question, answer)`.
 4. `FlashyCard.run()` calls `c.execute(knowledgeBase, ui, storage, session)`.
-5. `AddCommand.execute()` creates a new `Card(question, answer)`  the `Card` constructor auto assigns the next available `id` from the static counter.
+5. `AddCommand.execute()` creates a new `Card(question, answer)` — the `Card` constructor auto-assigns the next available `id` from the static counter.
 6. The card is added to `KnowledgeBase` via `cards.addCard(card)`.
 7. `storage.save(knowledgeBase)` writes the updated state to disk.
 8. `ui.showAddedMessage(card)` prints a confirmation to the terminal.
 
 #### Sequence Diagram
 
-![seq_add_a_card.png](diagram/seq_add_a_card.png)
+![Add Command Sequence](diagram/seq_add_a_card.png)
 
 #### Design Note
 
-`AddCommand` does **not** check for duplicate content, FlashyCard allows multiple cards with the same question. The only uniqueness constraint is the numeric `id`, which is guaranteed by the auto incrementing static counter in `Card`.
+`AddCommand` does **not** check for duplicate content — FlashyCard allows multiple cards with the same question. The only uniqueness constraint is the numeric `id`, which is guaranteed by the auto-incrementing static counter in `Card`.
 
 ---
 
@@ -262,12 +262,12 @@ This section explains each command in detail, including step-by-step walkthrough
 3. `DeleteCommand.execute()` calls `cards.deleteCard(cardId)`.
 4. `KnowledgeBase.deleteCard()` checks that the card exists; if not, throws `CardNotFoundException` which propagates to `FlashyCard.run()` and is shown as an error.
 5. If found, the card is removed from the `HashMap` and returned.
-6. **Note:** `DeleteCommand` does **not** call `storage.save()` this is a known behaviour where deletions are not immediately persisted unless `storage.save()` is triggered by a subsequent write command.
+6. `storage.save(knowledgeBase)` is called to immediately persist the deletion to disk.
 7. `ui.showDeletedMessage(deletedCard)` prints the confirmation.
 
 #### Sequence Diagram
 
-![seq_delete_a_card.png](diagram/seq_delete_a_card.png)
+![Delete Command Sequence](diagram/seq_delete_a_card.png)
 
 ---
 
@@ -286,19 +286,19 @@ At least one of `q/` or `a/` must be present; omitted fields are preserved from 
 1. User types `edit 1 q/What is Go? a/A compiled language`.
 2. `EditCommandParser` extracts `id=1`, `question="What is Go?"`, `answer="A compiled language"`.
 3. `EditCommand.execute()`:
-    - Calls `cards.getCardById(1)` to retrieve the existing card.
-    - Merges: if `newQuestion != null` use it, else keep `old.getQuestion()`. Same for answer. Tag is **always** preserved.
-    - Creates a new immutable `Card(old.getId(), updatedQuestion, updatedAnswer, old.getTag())`.
-    - Deletes the old card, adds the new card.
+   - Calls `cards.getCardById(1)` to retrieve the existing card.
+   - Merges: if `newQuestion != null` use it, else keep `old.getQuestion()`. Same for answer. Tag is **always** preserved.
+   - Creates a new immutable `Card(old.getId(), updatedQuestion, updatedAnswer, old.getTag())`.
+   - Deletes the old card, adds the new card.
 4. Calls `storage.save()` and `ui.showEditedMessage(edited)`.
 
 #### Sequence Diagram
 
-![seq_edit_a_card.png](diagram/seq_edit_a_card.png)
+![Edit Command Sequence](diagram/seq_edit_a_card.png)
 
-#### Design Note Immutability via Delete and Recreate
+#### Design Note — Immutability via Delete-and-Recreate
 
-Because `Card` is immutable, editing requires deleting the old object and inserting a new one with the same `id`. This pattern ensures that there is never a partially mutated card in memory. The same pattern is used by `TagCommand`.
+Because `Card` is immutable, editing requires deleting the old object and inserting a new one with the same `id`. This pattern ensures that there is never a partially-mutated card in memory. The same pattern is used by `TagCommand`.
 
 ---
 
@@ -314,11 +314,11 @@ Because `Card` is immutable, editing requires deleting the old object and insert
 
 1. User types `view 1`.
 2. `ViewCommand.execute()` calls `cards.getCardById(1)`.
-3. Calls `ui.showQuestion(selectedCard)`  only the question is shown, not the answer. This simulates the "front" of a flashcard.
+3. Calls `ui.showQuestion(selectedCard)` — only the question is shown, not the answer. This simulates the "front" of a flashcard.
 
 #### Sequence Diagram
 
-![seq_view_a_card.png](diagram/seq_view_a_card.png)
+![View Command Sequence](diagram/seq_view_a_card.png)
 
 ---
 
@@ -330,11 +330,11 @@ Because `Card` is immutable, editing requires deleting the old object and insert
 
 **Executed by:** `FlipCommand`
 
-Identical flow to `view`, but calls `ui.showAnswer(selectedCard)` to reveal the answer simulating the "back" of a flashcard.
+Identical flow to `view`, but calls `ui.showAnswer(selectedCard)` to reveal the answer — simulating the "back" of a flashcard.
 
 #### Sequence Diagram
 
-![seq_flip_a_card.png](diagram/seq_flip_a_card.png)
+![Flip Command Sequence](diagram/seq_flip_a_card.png)
 
 ---
 
@@ -355,11 +355,11 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 3. `FindCommand.execute()` streams all cards from `hb.getAllCards()`.
 4. Each card is filtered: if `scope == "q"`, only `card.getQuestion().toLowerCase().contains(keyword)` is checked.
 5. Matching cards are collected into a `List<Card>` and passed to `ui.showSearchResults(results, keyword)`.
-6. Results are **not** stored in `SessionContainer` by `FindCommand`  the caller may later `save all s/setName` using whatever last results were stored.
+6. **`FindCommand` does NOT call `session.setLastSearchResults()`** — results are displayed only. Only `ListCommand` and `TestCommand` populate `SessionContainer`. Users who want to `save all` must run `list` first.
 
 #### Sequence Diagram
 
-![seq_find_a_card.png](diagram/seq_find_a_card.png)
+![Find Command Sequence](diagram/seq_find_a_card.png)
 
 ---
 
@@ -375,14 +375,14 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 1. User types `list` (no set name).
 2. `ListCommand.execute()`:
-    - `setName == null`: adds all cards from `hb.getAllCards()` to `cardsToShow`.
-    - `setName != null`: looks up `hb.getAllTestSets().get(setName)`, retrieves each card by id.
-3. `session.setLastSearchResults(cardsToShow)` stores results for potential `save all`.
+   - `setName == null`: adds all cards from `hb.getAllCards()` to `cardsToShow`.
+   - `setName != null`: looks up `hb.getAllTestSets().get(setName)`, retrieves each card by id.
+3. `session.setLastSearchResults(cardsToShow)` — stores results so `save all` can use them.
 4. `ui.showSearchResults(cardsToShow, label)` prints the list.
 
 #### Sequence Diagram
 
-![seq_list_card.png](diagram/seq_list_card.png)
+![List Command Sequence](diagram/seq_list_card.png)
 
 ---
 
@@ -396,16 +396,16 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 #### Step-by-Step
 
-1. User types `save all s/revision` after a `list` or `find`.
+1. User types `save all s/revision` after a `list`.
 2. `SaveCommand.execute()`:
-    - If `target == "all"`: retrieves `session.getLastSearchResults()`. If empty, shows error.
-    - If `target` is a number: checks `hb.hasCard(id)`.
-3. Calls `hb.saveToTestSet(setName, idsToSave)` this appends to the set, skipping duplicates.
+   - If `target == "all"`: retrieves `session.getLastSearchResults()`. If empty, shows error. Note: only `list` and `test` populate this — `find` does not.
+   - If `target` is a number: checks `hb.hasCard(id)`.
+3. Calls `hb.saveToTestSet(setName, idsToSave)` — this appends to the set, skipping duplicates.
 4. Calls `storage.save(hb)` and `ui.showSaveSetSuccess(setName, count)`.
 
 #### Sequence Diagram
 
-![seq_save_test_set.png](diagram/seq_save_test_set.png)
+![Save Command Sequence](diagram/seq_save_test_set.png)
 
 ---
 
@@ -422,14 +422,14 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 1. User types `remove 1 2 s/revision`.
 2. `RemoveCommandParser` splits `target = "1 2"` into `[1, 2]`, creates `new RemoveCommand([1, 2], "revision")`.
 3. `RemoveCommand.execute()`:
-    - Checks set exists in `hb.getAllTestSets()`.
-    - If `cardIds == null` (remove all): replaces the set with an empty `ArrayList`.
-    - Otherwise: calls `hb.removeCardFromSet(setName, id)` for each id.
+   - Checks set exists in `hb.getAllTestSets()`.
+   - If `cardIds == null` (remove all): replaces the set with an empty `ArrayList`.
+   - Otherwise: calls `hb.removeCardFromSet(setName, id)` for each id.
 4. Calls `storage.save(hb)` after any successful removal.
 
 #### Sequence Diagram
 
-![seq_remove_from_test_set.png](diagram/seq_remove_from_test_set.png)
+![Remove Command Sequence](diagram/seq_remove_from_test_set.png)
 
 ---
 
@@ -447,15 +447,15 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 1. User types `test revision`.
 2. `TestCommand.execute()`:
-    - Retrieves the id list from `hb.getAllTestSets().get(setName)`.
-    - Validates the set exists and is not empty.
-    - Collects the `Card` objects into `testCards`.
-    - Stores cards in `session.setLastSearchResults(testCards)`.
-    - Calls `ui.startStudySession(testCards)` which runs the interactive quiz loop.
+   - Retrieves the id list from `hb.getAllTestSets().get(setName)`.
+   - Validates the set exists and is not empty.
+   - Collects the `Card` objects into `testCards`.
+   - Stores cards in `session.setLastSearchResults(testCards)` — this allows a subsequent `save all` to capture the test set's cards into another set.
+   - Calls `ui.startStudySession(testCards)` which runs the interactive quiz loop.
 
 #### Sequence Diagram
 
-![seq_test_a_set.png](diagram/seq_test_a_set.png)
+![Test Command Sequence](diagram/seq_test_a_set.png)
 
 ---
 
@@ -471,14 +471,14 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 1. User types `tag 1 t/programming`.
 2. `TagCommand.execute()`:
-    - Retrieves the old card via `cards.getCardById(id)`.
-    - Creates a new `Card(oldCard.getId(), oldCard.getQuestion(), oldCard.getAnswer(), tag)`.
-    - Deletes old, adds new (same delete-and-recreate pattern as `EditCommand`).
-    - Saves and shows confirmation.
+   - Retrieves the old card via `cards.getCardById(id)`.
+   - Creates a new `Card(oldCard.getId(), oldCard.getQuestion(), oldCard.getAnswer(), tag)`.
+   - Deletes old, adds new (same delete-and-recreate pattern as `EditCommand`).
+   - Saves and shows confirmation.
 
 #### Sequence Diagram
 
-![seq_tag_a_card.png](diagram/seq_tag_a_card.png)
+![Tag Command Sequence](diagram/seq_tag_a_card.png)
 
 ---
 
@@ -494,7 +494,7 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 #### Sequence Diagram
 
-![seq_list_all_tags.png](diagram/seq_list_all_tags.png)
+![Tags Command Sequence](diagram/seq_list_all_tags.png)
 
 ---
 
@@ -510,7 +510,7 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 #### Sequence Diagram
 
-![seq_exit.png](diagram/seq_exit.png)
+![Exit Command Sequence](diagram/seq_exit.png)
 
 ---
 
@@ -521,17 +521,17 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 1. `storage.save(knowledgeBase)` is called.
 2. A `BufferedWriter` is opened on the file path (overwriting the file entirely).
 3. For each `Card` in `knowledgeBase.getAllCards()`:
-    - `|` characters in `question`, `answer`, and `tag` are escaped to `\|`.
-    - Writes line: `id|question|answer|tag`.
+   - `|` characters in `question`, `answer`, and `tag` are escaped to `\|`.
+   - Writes line: `id|question|answer|tag`.
 4. For each test set entry in `knowledgeBase.getAllTestSets()`:
-    - Set name `|` chars are escaped.
-    - Card IDs are joined by `,`.
-    - Writes line: `SET:setName|id1,id2,...`.
+   - Set name `|` chars are escaped.
+   - Card IDs are joined by `,`.
+   - Writes line: `SET:setName|id1,id2,...`.
 5. Writer is closed.
 
 #### Sequence Diagram
 
-![seq_save_operations.png](diagram/seq_save_operations.png)
+![Storage Save Sequence](diagram/seq_save_operations.png)
 
 ---
 
@@ -543,19 +543,19 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 2. A `BufferedReader` reads the file line by line.
 3. Blank lines are skipped.
 4. Lines starting with `SET:` are parsed by `parseAndAddTestSet()`:
-    - Strips `SET:` prefix, splits on unescaped `|`, reads set name and comma-separated IDs.
+   - Strips `SET:` prefix, splits on unescaped `|`, reads set name and comma-separated IDs.
 5. Other lines are split on unescaped `|` into 3–4 parts.
-    - Part 0 → `id` (must parse as integer, else `CorruptedDataException`).
-    - Part 1 → `question` (unescape `\|`).
-    - Part 2 → `answer` (unescape `\|`).
-    - Part 3 → `tag` (or `"none"` if absent).
+   - Part 0 → `id` (must parse as integer, else `CorruptedDataException`).
+   - Part 1 → `question` (unescape `\|`).
+   - Part 2 → `answer` (unescape `\|`).
+   - Part 3 → `tag` (or `"none"` if absent).
 6. A `Card(id, question, answer, tag)` is created — this also syncs `idCounter` so new cards get higher ids.
 7. Card is added to the `KnowledgeBase`.
 8. Populated `KnowledgeBase` is returned.
 
 #### Sequence Diagram
 
-![seq_load_operations.png](diagram/seq_load_operations.png)
+![Storage Load Sequence](diagram/seq_load_operations.png)
 
 ---
 
@@ -569,30 +569,30 @@ The optional `q/` or `a/` prefix restricts the search to questions or answers re
 
 ### Value Proposition
 
-FlashyCard lets students create, organise, and self-test with flashcards entirely from the terminal faster than GUI apps for users who type quickly. Test sets allow targeted revision of specific topics without manually filtering cards each time.
+FlashyCard lets students create, organise, and self-test with flashcards entirely from the terminal — faster than GUI apps for users who type quickly. Test sets allow targeted revision of specific topics without manually filtering cards each time.
 
 ---
 
 ## User Stories
 
-| Version | As a …      | I want to …                              | So that I can …                             |
-|---------|-------------|------------------------------------------|---------------------------------------------|
-| v1.0    | new user    | add flashcards with a question/answer    | build my knowledge base                     |
-| v1.0    | user        | list all my flashcards                   | see what I have stored                      |
-| v1.0    | user        | view a card's question                   | test my recall before flipping              |
-| v1.0    | user        | flip a card to see the answer            | verify whether I recalled correctly         |
-| v1.0    | user        | delete a card                            | remove outdated or incorrect cards          |
-| v2.0    | user        | edit an existing card                    | fix mistakes without deleting and re-adding |
-| v2.0    | user        | tag cards with a category                | organise cards by topic                     |
-| v2.0    | user        | find cards by keyword                    | locate specific cards quickly               |
-| v2.0    | user        | find cards only in questions or answers  | perform scoped search efficiently           |
-| v2.0    | user        | see all unique tags in my knowledge base | understand what categories I have           |
-| v2.0    | user        | save search results to a test set        | create targeted revision sets               |
-| v2.0    | user        | save a specific single card to a set     | build sets card by card                     |
-| v2.0    | user        | run a test session on a set              | quiz myself on a specific topic             |
-| v2.0    | user        | remove a card from a test set            | keep sets relevant                          |
-| v2.0    | user        | clear all cards from a test set          | reset a revision set quickly                |
-| v2.0    | user        | list cards in a specific test set        | review what a set contains                  |
+| Version | As a …   | I want to …                              | So that I can …                             |
+|---------|----------|------------------------------------------|---------------------------------------------|
+| v1.0    | new user | add flashcards with a question/answer    | build my knowledge base                     |
+| v1.0    | user     | list all my flashcards                   | see what I have stored                      |
+| v1.0    | user     | view a card's question                   | test my recall before flipping              |
+| v1.0    | user     | flip a card to see the answer            | verify whether I recalled correctly         |
+| v1.0    | user     | delete a card                            | remove outdated or incorrect cards          |
+| v2.0    | user     | edit an existing card                    | fix mistakes without deleting and re-adding |
+| v2.0    | user     | tag cards with a category                | organise cards by topic                     |
+| v2.0    | user     | find cards by keyword                    | locate specific cards quickly               |
+| v2.0    | user     | find cards only in questions or answers  | perform scoped search efficiently           |
+| v2.0    | user     | see all unique tags in my knowledge base | understand what categories I have           |
+| v2.0    | user     | save search results to a test set        | create targeted revision sets               |
+| v2.0    | user     | save a specific single card to a set     | build sets card by card                     |
+| v2.0    | user     | run a test session on a set              | quiz myself on a specific topic             |
+| v2.0    | user     | remove a card from a test set            | keep sets relevant                          |
+| v2.0    | user     | clear all cards from a test set          | reset a revision set quickly                |
+| v2.0    | user     | list cards in a specific test set        | review what a set contains                  |
 
 ---
 
@@ -601,27 +601,27 @@ FlashyCard lets students create, organise, and self-test with flashcards entirel
 1. **Portability:** Should work on Windows, macOS, and Linux with Java 17 installed.
 2. **Performance:** All commands should respond within 1 second for a knowledge base of up to 10,000 cards.
 3. **Persistence:** Data must persist across sessions without requiring manual saving by the user.
-4. **Human-Readability:** The data file (`data/flashcards.txt`) should be human readable for manual inspection or backup.
+4. **Human-Readability:** The data file (`data/flashcards.txt`) should be human-readable for manual inspection or backup.
 5. **Robustness:** The application must not crash on invalid user input; all errors must display descriptive messages.
-6. **Correctness:** Corrupted storage files must not silently produce wrong data  `CorruptedDataException` must be thrown and handled gracefully, starting with an empty knowledge base.
+6. **Correctness:** Corrupted storage files must not silently produce wrong data — `CorruptedDataException` must be thrown and handled gracefully, starting with an empty knowledge base.
 
 ---
 
 ## Glossary
 
-| Term | Definition                                                                                                                   |
-|------|------------------------------------------------------------------------------------------------------------------------------|
-| **Card** | A flashcard consisting of an auto assigned integer ID, a question string, an answer string, and a tag string.                |
-| **KnowledgeBase** | The in-memory store of all cards and test sets for one application run.                                                      |
-| **Test Set** | A named collection of card IDs used for focused study sessions.                                                              |
-| **Tag** | A category label assigned to a card. Default value is `"none"`.                                                              |
-| **SessionContainer** | Holds transient per session state (last search results, active study session) that is not persisted.                         |
-| **StudySession** | A stateful iterator over a list of cards used during a `test` command session.                                               |
-| **CommandParser** | An abstract class whose concrete subclasses each know how to parse one command type.                                         |
-| **Command** | An abstract class whose concrete subclasses each know how to execute one command type.                                       |
+| Term | Definition |
+|------|-----------|
+| **Card** | A flashcard consisting of an auto-assigned integer ID, a question string, an answer string, and a tag string. |
+| **KnowledgeBase** | The in-memory store of all cards and test sets for one application run. |
+| **Test Set** | A named collection of card IDs used for focused study sessions. |
+| **Tag** | A category label assigned to a card. Default value is `"none"`. |
+| **SessionContainer** | Holds transient per-session state (last list/test results, active study session) that is not persisted to disk. |
+| **StudySession** | A stateful iterator over a list of cards used during a `test` command session. |
+| **CommandParser** | An abstract class whose concrete subclasses each know how to parse one command type. |
+| **Command** | An abstract class whose concrete subclasses each know how to execute one command type. |
 | **idCounter** | A static field in `Card` that auto-increments to assign unique IDs. It is synced upward whenever cards are loaded from disk. |
-| **Escaped pipe** | The sequence `\|` used in the storage file to represent a literal `                                                          |` character within a field value. |
-| **CorruptedDataException** | A checked exception thrown by `Storage.load()` when the file format is invalid.                                              |
+| **Escaped pipe** | The sequence `\|` used in the storage file to represent a literal `|` character within a field value. |
+| **CorruptedDataException** | A checked exception thrown by `Storage.load()` when the file format is invalid. |
 
 ---
 
@@ -641,7 +641,7 @@ Or run `FlashyCard.main()` directly from your IDE.
 
 ### Loading Sample Data
 
-To test with pre-existing data, create `data/flashcards.txt` in the same folder as the JAR (or project root) with this content:
+To test with pre-existing data, create `data/flashcards.txt` in the same folder as the JAR with this content:
 
 ```
 1|What is Java?|A programming language|none
@@ -650,41 +650,29 @@ To test with pre-existing data, create `data/flashcards.txt` in the same folder 
 SET:mySet|1,2
 ```
 
-Then launch the app it will load 3 cards and 1 test set automatically.
+Then launch the app — it will load 3 cards and 1 test set automatically.
 
 ---
 
 ### Test Case 1: Adding a Card
 
-**Input:**
+**Input:** `add q/What is Python? a/A scripting language`
 
-```
-add q/What is Python? a/A scripting language
-```
-
-**Expected:** Confirmation message showing the new card's assigned ID (e.g., `#4` if 3 cards were preloaded).
+**Expected:** Confirmation message showing the new card's assigned ID (e.g., `#4` if 3 cards were pre-loaded).
 
 ---
 
 ### Test Case 2: Adding a Card with Missing Fields
 
-**Input:**
+**Input:** `add q/Only a question`
 
-```
-add q/Only a question
-```
-
-**Expected:** `ERROR` message the regex requires both `q/` and `a/` flags.
+**Expected:** `ERROR: Invalid argument format given for add command`
 
 ---
 
 ### Test Case 3: Listing All Cards
 
-**Input:**
-
-```
-list
-```
+**Input:** `list`
 
 **Expected:** All cards shown with their IDs, questions, and tags.
 
@@ -692,12 +680,7 @@ list
 
 ### Test Case 4: Viewing and Flipping
 
-**Input:**
-
-```
-view 1
-flip 1
-```
+**Input:** `view 1` then `flip 1`
 
 **Expected:** First command shows only the question. Second shows only the answer.
 
@@ -705,192 +688,152 @@ flip 1
 
 ### Test Case 5: Viewing a Non-Existent Card
 
-**Input:**
+**Input:** `view 999`
 
-```
-view 999
-```
-
-**Expected:** `ERROR`  "Card with given ID cannot be found in the knowledge base".
+**Expected:** `ERROR: Card with given ID cannot be found in the knowledge base`
 
 ---
 
 ### Test Case 6: Editing a Card
 
 **Input:**
-
 ```
 edit 1 q/What is Go? a/A compiled language
 edit 2 q/What is Abstraction?
 edit 3 a/Four
 ```
 
-**Expected:** Only the specified fields change. Tag is always preserved. Confirming with `view` / `flip` shows updated values.
+**Expected:** Only the specified fields change. Tag is always preserved.
 
 ---
 
 ### Test Case 7: Editing with No Fields
 
-**Input:**
+**Input:** `edit 1`
 
-```
-edit 1
-```
-
-**Expected:** `ERROR` "Edit command requires at least q/QUESTION or a/ANSWER."
+**Expected:** `ERROR: Edit command requires at least q/QUESTION or a/ANSWER.`
 
 ---
 
 ### Test Case 8: Tagging
 
-**Input:**
+**Input:** `tag 1 t/programming` then `tags`
 
-```
-tag 1 t/programming
-tags
-```
-
-**Expected:** Card 1 now has tag `programming`. The `tags` command lists all unique tags including `programming`.
+**Expected:** Card 1 now has tag `programming`. The `tags` command lists all unique tags.
 
 ---
 
 ### Test Case 9: Finding Cards
 
 **Input:**
-
 ```
 find java
 find q/What
 find a/Four
 ```
 
-**Expected:** First finds cards with "java" in question or answer. Second finds cards with "What" in question only. Third finds cards with "Four" in answer only.
+**Expected:** Results displayed in each case. Note: `find` results cannot be used with `save all` — run `list` first for that.
 
 ---
 
-### Test Case 10: Saving to a Test Set
+### Test Case 10: Save All Requires Prior List
 
 **Input:**
+```
+find java
+save all s/findtest
+```
 
+**Expected:** `ERROR: No previous search results found to save. Try 'find' or 'list' first.`
+This confirms that `find` does not populate `SessionContainer`. Run `list` first.
+
+---
+
+### Test Case 11: Saving to a Test Set via List
+
+**Input:**
 ```
 list
 save all s/revision
 save 1 s/singles
 ```
 
-**Expected:** After `list`, all cards are in `SessionContainer`. `save all` saves them all to `revision`. `save 1` saves only card 1 to `singles`.
+**Expected:** After `list`, all cards are in `SessionContainer`. `save all` saves them to `revision`. `save 1` saves only card 1 to `singles`.
 
 ---
 
-### Test Case 11: Listing a Test Set
+### Test Case 12: Listing a Test Set
 
-**Input:**
-
-```
-list s/revision
-list s/nonexistent
-```
+**Input:** `list s/revision` then `list s/nonexistent`
 
 **Expected:** First shows cards in `revision`. Second shows an error.
 
 ---
 
-### Test Case 12: Testing a Set
+### Test Case 13: Testing a Set
 
-**Input:**
+**Input:** `test revision`
 
-```
-test revision
-```
-
-**Expected:** Interactive quiz starts. Cards are shown one by one. Final score is printed at the end.
+**Expected:** Interactive quiz starts. Cards shown one by one. Score printed at end.
 
 ---
 
-### Test Case 13: Removing from a Set
+### Test Case 14: Removing from a Set
 
 **Input:**
-
 ```
 remove 1 s/revision
 remove all s/singles
 list s/revision
 ```
 
-**Expected:** Card 1 is no longer in `revision`. `singles` is now empty. `list s/revision` shows the remaining cards.
+**Expected:** Card 1 removed from `revision`. `singles` is empty. `list s/revision` shows remaining cards.
 
 ---
 
-### Test Case 14: Deleting a Card
+### Test Case 15: Deleting a Card
 
-**Input:**
+**Input:** `delete 2` then `list`
 
-```
-delete 2
-list
-```
-
-**Expected:** Card 2 no longer appears in `list`.
+**Expected:** Card 2 no longer appears. Deletion is immediately persisted — if app is relaunched, card 2 is still gone.
 
 ---
 
-### Test Case 15: Deleting a Non-Existent Card
+### Test Case 16: Deleting a Non-Existent Card
 
-**Input:**
+**Input:** `delete 999`
 
-```
-delete 999
-```
-
-**Expected:** `ERROR`  descriptive not found message.
+**Expected:** `ERROR: Cannot delete card: Card with given ID cannot be found in the knowledge base`
 
 ---
 
-### Test Case 16: Persistence Check
+### Test Case 17: Persistence Check
 
-1. Add some cards and save a test set.
+1. Add cards and save a test set.
 2. Type `exit`.
 3. Relaunch the app.
-4. Type `list` all previously created cards and sets should still be present.
+4. Type `list` — all cards and sets should still be present.
 
 ---
 
-### Test Case 17: Corrupted Data File
+### Test Case 18: Corrupted Data File
 
 1. Open `data/flashcards.txt` in a text editor.
 2. Delete part of a line so it has fewer than 3 pipe-separated fields.
 3. Relaunch the app.
 
-**Expected:** The app prints a data-corruption warning and starts with an empty knowledge base it does **not** crash.
-
----
-
-### Test Case 18: Invalid Commands
-
-```
-edit 999 q/Test
-edit 1
-delete 999
-flip 999
-add q/Missing answer
-save all s/rev
-```
-
-The last line (`save all`) should error because no `list` or `find` was run first.
-
-**Expected:** Each produces a descriptive `ERROR` message.
+**Expected:** App prints a data-corruption warning and starts with an empty knowledge base. Does **not** crash.
 
 ---
 
 ### Test Case 19: Pipe Character in Card Content
 
 **Input:**
-
 ```
 add q/What does A|B mean? a/Bitwise OR operation
 flip [id]
 ```
 
-**Expected:** The card is stored and retrieved correctly with the `|` character intact (it is escaped as `\|` in the file, then unescaped on load).
+**Expected:** Card stored and retrieved correctly with the `|` character intact.
 
 ---


### PR DESCRIPTION

Closes #112, #85, #84, #83, #71, #70

> Note: #80 and #79 (PDF not hyperlinked / text not selectable) are resolved by re exporting the PDF from the updated markdown source.

### Changes

**Accuracy fixes**
- #112 / #83 / #71: Updated DeleteCommand Step-by-Step (Step 6) to correctly state that `storage.save()` is now called after deletion, consistent with the implemented fix
- #85: Fixed SessionContainer section — removed incorrect claim that `FindCommand` populates `lastSearchResults`. Now correctly states that only `ListCommand` and `TestCommand` do so
- #70: Updated FindCommand deep-dive to explicitly state that `FindCommand` does NOT call `session.setLastSearchResults()`, and added a note explaining that users must run `list` before `save all`
- #84: DG and UG are now consistent — delete persists immediately

**Other**
- Updated SaveCommand Step-by-Step to clarify that `save all` requires a prior `list` or `test`, not `find`
- Added Test Case 10 to Manual Testing: verifies that `find` followed by `save all` correctly errors
- Updated Test Case 15 (delete) to confirm deletion is immediately persisted
- Fixed Glossary entry for SessionContainer to say "last list/test results" instead of "last search results"